### PR TITLE
Adding dataset metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,75 @@ We've also included `generate_to_file.py` as an example of how to write the
 generated examples to text files. You can use this directly, or adapt it for
 your generation and training needs.
 
+## Dataset Metadata
+The following table is necessary for this dataset to be indexed by search
+engines such as <a href="https://g.co/datasetsearch">Google Dataset Search</a>.
+<div itemscope itemtype="http://schema.org/Dataset">
+<table>
+  <tr>
+    <th>property</th>
+    <th>value</th>
+  </tr>
+  <tr>
+    <td>name</td>
+    <td><code itemprop="name">Mathematics Dataset</code></td>
+  </tr>
+  <tr>
+    <td>url</td>
+    <td><code itemprop="url">https://github.com/deepmind/mathematics_dataset</code></td>
+  </tr>
+  <tr>
+    <td>sameAs</td>
+    <td><code itemprop="sameAs">https://github.com/deepmind/mathematics_dataset</code></td>
+  </tr>
+  <tr>
+    <td>description</td>
+    <td><code itemprop="description">This dataset consists of mathematical question and answer pairs, from a range
+of question types at roughly school-level difficulty. This is designed to test
+the mathematical learning and algebraic reasoning skills of learning models.\n
+\n
+It contains 2 million
+(question, answer) pairs per module, with questions limited to 160 characters in
+length, and answers to 30 characters in length. Note the training data for each
+question type is split into "train-easy", "train-medium", and "train-hard". This
+allows training models via a curriculum. The data can also be mixed together
+uniformly from these training datasets to obtain the results reported in the
+paper. Categories:\n
+\n
+* **algebra** (linear equations, polynomial roots, sequences)\n
+* **arithmetic** (pairwise operations and mixed expressions, surds)\n
+* **calculus** (differentiation)\n
+* **comparison** (closest numbers, pairwise comparisons, sorting)\n
+* **measurement** (conversion, working with time)\n
+* **numbers** (base conversion, remainders, common divisors and multiples,\n
+  primality, place value, rounding numbers)\n
+* **polynomials** (addition, simplification, composition, evaluating, expansion)\n
+* **probability** (sampling without replacement)</code></td>
+  </tr>
+  <tr>
+    <td>provider</td>
+    <td>
+      <div itemscope itemtype="http://schema.org/Organization" itemprop="provider">
+        <table>
+          <tr>
+            <th>property</th>
+            <th>value</th>
+          </tr>
+          <tr>
+            <td>name</td>
+            <td><code itemprop="name">DeepMind</code></td>
+          </tr>
+          <tr>
+            <td>sameAs</td>
+            <td><code itemprop="sameAs">https://en.wikipedia.org/wiki/DeepMind</code></td>
+          </tr>
+        </table>
+      </div>
+    </td>
+  </tr>
+  <tr>
+    <td>citation</td>
+    <td><code itemprop="citation">https://identifiers.org/arxiv:1904.01557</code></td>
+  </tr>
+</table>
+</div>

--- a/README.md
+++ b/README.md
@@ -117,6 +117,19 @@ engines such as <a href="https://g.co/datasetsearch">Google Dataset Search</a>.
 of question types at roughly school-level difficulty. This is designed to test
 the mathematical learning and algebraic reasoning skills of learning models.\n
 \n
+## Example questions\n
+\n
+```\n
+Question: Solve -42*r + 27*c = -1167 and 130*r + 4*c = 372 for r.\n
+Answer: 4\n
+\n
+Question: Calculate -841880142.544 + 411127.\n
+Answer: -841469015.544\n
+\n
+Question: Let x(g) = 9*g + 1. Let q(c) = 2*c + 1. Let f(i) = 3*i - 39. Let w(j) = q(x(j)). Calculate f(w(a)).\n
+Answer: 54*a - 30\n
+```\n
+\n
 It contains 2 million
 (question, answer) pairs per module, with questions limited to 160 characters in
 length, and answers to 30 characters in length. Note the training data for each


### PR DESCRIPTION
This PR adds Schema.org/Dataset metadata making this dataset indexable by search engines such as [Google Dataset Search](https://g.co/datasetsearch).

Validation: https://search.google.com/structured-data/testing-tool#url=https%3A%2F%2Fgithub.com%2Fchrisgorgo%2Fmathematics_dataset%2Fblob%2Fenh%2Fmetadata%2FREADME.md