### PR TITLE
Refactor deprecated unittest aliases for Python 3.11 compatibility.

### DIFF
--- a/mathematics_dataset/util/composition_test.py
+++ b/mathematics_dataset/util/composition_test.py
@@ -54,7 +54,7 @@ class ContextTest(absltest.TestCase):
 class EntityTest(absltest.TestCase):
 
   def testInit_valueErrorIfSelfAndHandle(self):
-    with self.assertRaisesRegexp(ValueError, 'Cannot specify handle'):
+    with self.assertRaisesRegex(self, ValueError, 'Cannot specify handle'):
       composition.Entity(context=composition.Context(),
                          value=0,
                          description='Something with {self}. ',

--- a/mathematics_dataset/util/display_test.py
+++ b/mathematics_dataset/util/display_test.py
@@ -81,7 +81,7 @@ class DecimalTest(absltest.TestCase):
 
   def testInt_errorIfNonInt(self):
     decimal = display.Decimal(sympy.Rational(1, 2))
-    with self.assertRaisesRegexp(TypeError, 'Cannot represent'):
+    with self.assertRaisesRegex(self, TypeError, 'Cannot represent'):
       int(decimal)
 
   def testComparison(self):
@@ -175,7 +175,7 @@ class StringOrdinalTest(absltest.TestCase):
     self.assertEqual(str(ordinal), 'tenth')
 
   def testCreate_errorIfNegative(self):
-    with self.assertRaisesRegexp(ValueError, 'Unsupported ordinal'):
+    with self.assertRaisesRegex(self, ValueError, 'Unsupported ordinal'):
       display.StringOrdinal(-1)
 
 


### PR DESCRIPTION
The deprecated aliases were removed in Python 3.11 in https://github.com/python/cpython/pull/28268 . Use six for a compatible function present in both Python 2 and Python 3.