### PR TITLE
Refactor polynomial sampling code for compatibility

### DIFF
--- a/mathematics_dataset/sample/polynomials.py
+++ b/mathematics_dataset/sample/polynomials.py
@@ -30,7 +30,10 @@ import six
 from six.moves import range
 from six.moves import zip
 import sympy
-from sympy.solvers.diophantine.diophantine import base_solution_linear as diophantine_solve_linear_2d
+try:
+    from sympy.solvers.diophantine.diophantine import base_solution_linear as diophantine_solve_linear_2d
+except ImportError:
+    from sympy.solvers.diophantine import base_solution_linear as diophantine_solve_linear_2d
 
 
 def expanded_coefficient_counts(length, is_zero):

--- a/mathematics_dataset/sample/polynomials.py
+++ b/mathematics_dataset/sample/polynomials.py
@@ -30,7 +30,7 @@ import six
 from six.moves import range
 from six.moves import zip
 import sympy
-from sympy.solvers.diophantine import base_solution_linear as diophantine_solve_linear_2d
+from sympy.solvers.diophantine.diophantine import base_solution_linear as diophantine_solve_linear_2d
 
 
 def expanded_coefficient_counts(length, is_zero):
@@ -238,7 +238,7 @@ def expand_coefficients(coefficients, entropy, length=None):
   coefficients = np.asarray(coefficients)
   shape = coefficients.shape
 
-  expanded_coefficients = np.empty(shape, dtype=np.object)
+  expanded_coefficients = np.empty(shape, dtype=object)
 
   min_length = np.count_nonzero(coefficients) + 2
   if length is None:
@@ -363,8 +363,8 @@ def coefficients_linear_split(coefficients, entropy):
   if random.choice([False, True]):
     a, b = b, a
 
-  coefficients_1 = np.zeros(coefficients.shape, dtype=np.object)
-  coefficients_2 = np.zeros(coefficients.shape, dtype=np.object)
+  coefficients_1 = np.zeros(coefficients.shape, dtype=object)
+  coefficients_2 = np.zeros(coefficients.shape, dtype=object)
 
   for index, coefficient in enumerate(coefficients):
     entropy_coeff = entropy_coefficients[index]


### PR DESCRIPTION
## Description
- Updated import path for `base_solution_linear` function from `sympy.solvers.diophantine.diophantine` to ensure compatibility with the latest sympy version.
- Replaced `np.object` with `object` for dtype specifications in numpy arrays to avoid deprecation warnings.
- These changes improve code compatibility with newer libraries.

## Files Changed
- `mathematics_dataset/sample/polynomials.py`

## Detailed Changes
1. **Import Path Update:**
   - Changed (Edit):
     ```python
     from sympy.solvers.diophantine import base_solution_linear as diophantine_solve_linear_2d
     ```
     to:
     ```python
     try:
         from sympy.solvers.diophantine.diophantine import base_solution_linear as diophantine_solve_linear_2d
     except ImportError:
         from sympy.solvers.diophantine import base_solution_linear as diophantine_solve_linear_2d
     ```
  
2. **Numpy Dtype Adjustment:**
   - Updated dtype from `np.object` to `object` in the following lines:
     ```python
     expanded_coefficients = np.empty(shape, dtype=np.object)
     ```
     to:
     ```python
     expanded_coefficients = np.empty(shape, dtype=object)
     ```
   - Similarly, adjusted dtype in:
     ```python
     coefficients_1 = np.zeros(coefficients.shape, dtype=np.object)
     coefficients_2 = np.zeros(coefficients.shape, dtype=np.object)
     ```
     to:
     ```python
     coefficients_1 = np.zeros(coefficients.shape, dtype=object)
     coefficients_2 = np.zeros(coefficients.shape, dtype=object)
     ```