### PR TITLE
The numpy.ndarray.itemset method was removed from NumPy 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*~
+.DS_Store
+__pycache__
+*.egg-info
+build

--- a/mathematics_dataset/sample/polynomials.py
+++ b/mathematics_dataset/sample/polynomials.py
@@ -219,7 +219,7 @@ def sample_coefficients(degrees, entropy, min_non_zero=0, max_non_zero=None):
 
   for index, entry_entropy in zip(indices, entropies):
     value = number.integer(entry_entropy, signed=True, min_abs=1)
-    coeffs.itemset(index, value)
+    coeffs[index] = value
 
   return coeffs
 
@@ -262,7 +262,7 @@ def expand_coefficients(coefficients, entropy, length=None):
         value=coefficients.item(power),
         count=counts.item(power),
         entropy=coeffs_entropy.item(power))
-    expanded_coefficients.itemset(power, coeffs)
+    expanded_coefficients[power] = coeffs
 
   return expanded_coefficients
 


### PR DESCRIPTION
This just changes a few itemset calls to array index setting calls. The old itemset calls fails on newer numpy versions.

## Environment 

`% python --version` => Python 3.11.11

```python
>>> import numpy
>>> numpy.version.version
'2.2.5'
```

## Fixing Issue

`% python -m mathematics_dataset.generate --filter=linear_1d`

```
Traceback (most recent call last):
 ...
  File "/Users/robrohan/Projects/SideProjects/mathematics_dataset/mathematics_dataset/sample/polynomials.py", line 222, in sample_coefficients
    coeffs.itemset(index, value)
    ^^^^^^^^^^^^^^
AttributeError: `itemset` was removed from the ndarray class in NumPy 2.0. Use `arr[index] = value` instead.
```

After the change it generates correctly.
